### PR TITLE
Fix for Latest pywemo

### DIFF
--- a/octoprint_psucontrol_wemo/__init__.py
+++ b/octoprint_psucontrol_wemo/__init__.py
@@ -70,7 +70,7 @@ class PSUControl_Wemo(octoprint.plugin.StartupPlugin,
                 port = pywemo.ouimeaux_device.probe_wemo(plugip)
             url = "http://{}:{}/setup.xml".format(plugip, port)
             url = url.replace(':None', '')
-            device = pywemo.discovery.device_from_description(url, None)
+            device = pywemo.discovery.device_from_description(url)
 
             if cmd == "info":
                 return device.get_state()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 OctoPrint
-pywemo
+pywemo~=1.0


### PR DESCRIPTION
The latest version (> 0.9.2) of pywemo removed the second parameter from device_from_description. See [version 1.0.0](https://github.com/pywemo/pywemo/blob/dc9786c33b0dd1ee0ecd5c3b1803efb797dfd3b8/pywemo/discovery.py#L56C1-L56C1) vs [version 0.9.2](https://github.com/pywemo/pywemo/blob/aba1b738c2ca603e5c0a98bde23e26a802421da9/pywemo/discovery.py#L57)